### PR TITLE
Feature-alternate-models

### DIFF
--- a/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
+++ b/src/StudentAffairsUwm/Shibboleth/Controllers/ShibbolethController.php
@@ -185,7 +185,7 @@ class ShibbolethController extends Controller
             $data['error'] = 'Incorrect username and/or password';
         }
 
-        return view('vendor.shibalike.IdpLogin', $data);
+        return $this->viewOrRedirect(config('shibboleth.emulate_idp_login_view'));
     }
 
     /**

--- a/src/StudentAffairsUwm/Shibboleth/Providers/ShibbolethUserProvider.php
+++ b/src/StudentAffairsUwm/Shibboleth/Providers/ShibbolethUserProvider.php
@@ -32,7 +32,9 @@ class ShibbolethUserProvider implements UserProviderInterface
      */
     public function retrieveById($identifier)
     {
-        $user = $this->retrieveByCredentials(['id' => $identifier]);
+        $userClass = config('auth.providers.users.model', 'App\User');
+
+        $user = $this->retrieveByCredentials([(new $userClass)->getKeyName() => $identifier]);
         return ($user && $user->getAuthIdentifier() == $identifier) ?
             $user : null;
     }

--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -60,6 +60,8 @@ return array(
      */
 
     'emulate_idp'       => env('SHIB_EMULATE', false),
+    //can also be a url to redirect to
+    'emulate_idp_login_view'   => env('SHIB_EMULATE_LOGIN_VIEW', 'vendor.shibalike.IdpLogin'),
     'emulate_idp_users' => array(
         'admin' => array(
             'uid'         => 'admin',


### PR DESCRIPTION
Small update to help with compatibility to our MAT project – and other users in general. 
- Use the `getKeyName` method from the provided eloquent model to support non `id` model primary keys.
- Add `SHIB_EMULATE_LOGIN_VIEW` environment variable and use the `viewOrRedirect` to support non blade emulation login pages. 